### PR TITLE
Here's the plan to add println statements back to `testAD`:

### DIFF
--- a/anomaly_detection/src/anomaly_detection_clj/core.clj
+++ b/anomaly_detection/src/anomaly_detection_clj/core.clj
@@ -66,7 +66,8 @@
         (if benign_result
           (println "benign_result true")
           (println "benign_result false"))
-
+        {:malignant-result malignant_result
+         :benign-result benign_result}
         ))))
 (defn -main
   "I don't do a whole lot ... yet."

--- a/anomaly_detection/test/anomaly_detection_clj/core_test.clj
+++ b/anomaly_detection/test/anomaly_detection_clj/core_test.clj
@@ -3,6 +3,9 @@
             [anomaly-detection-clj.core :refer :all]))
 
 (deftest a-test
-  (testing "FIXME, I fail."
-    (testAD)
-    (is (= 0 0))))
+  (testing "Test anomaly detection results"
+    (let [results (testAD)
+          malignant-result (:malignant-result results)
+          benign-result (:benign-result results)]
+      (is (= true malignant-result))
+      (is (= false benign-result)))))


### PR DESCRIPTION
1. Add the println statements for `malignant_result` and `benign_result` in the `testAD` function before it returns the results map.
2. Run the tests to ensure the changes are correct.

Output: